### PR TITLE
Move Show/Hide Bot Comments button to the right

### DIFF
--- a/comment-filter.js
+++ b/comment-filter.js
@@ -181,6 +181,6 @@ function updateBotToggle() {
 botToggle.style.position = "fixed";
 botToggle.style.zIndex = "1000";
 botToggle.style.bottom = "0";
-botToggle.style.left = "0";
+botToggle.style.right = "0";
 botToggle.addEventListener('click', toggleBotComments);
 document.body.appendChild(botToggle);


### PR DESCRIPTION
On the old gerrit UI, the Hide Bot Comments covers up the
publish and submit buttons by about 90%.  You can still click around
them but if your aim isn't true then you end up toggling bot
comments instead of submitting your own comments.

This change moves the button to the bottom-right of the screen instead
of the bottom-left so no buttons are covered up

Not tested on the new Gerrit UI
